### PR TITLE
dopostprocess is actually better as false

### DIFF
--- a/lua/worldportals/render_cl.lua
+++ b/lua/worldportals/render_cl.lua
@@ -83,10 +83,11 @@ hook.Add( "RenderScene", "WorldPortals_Render", function( plyOrigin, plyAngle )
 					h = ScrH(),
 					origin = camOrigin,
 					angles = camAngle,
-					dopostprocess = true,
+					dopostprocess = false,
 					drawhud = false,
 					drawmonitors = false,
-					drawviewmodel = false
+					drawviewmodel = false,
+					bloomtone = true
 					--zfar = 1500
 				} )
 			wp.drawing = false


### PR DESCRIPTION
I'm using identical rendering for my bullet hole project, and this made it easier to see a difference between `dopostprocess` being set as `false` and `true`.

**This is what it looks like as `true`:**
![Bad looking](https://i.imgur.com/f6y9DW6.jpg)
**This is what it looks like as `false`:**
![Good looking](https://i.imgur.com/AaHXSrF.jpg)

As you can see, with it set as `true`, there's a visible edge that makes it look fake.
Sorry, I didn't know about this when pull requesting the last thing.

I also set `bloomtone` as `true`, [because it actually disables bloom instead of enabling it as I originally thought it did](https://wiki.garrysmod.com/page/Structures/ViewData).

**Even with these changes, post processing and bloom effects still work naturally on the view.**
![Post processing and bloom](https://i.imgur.com/D86Dbb9.jpg)
They just don't double up and look odd like they do at the moment.

I'm not sure if you should merge this. For a Tardis where the lighting doesn't need to match the background, it probably doesn't matter.