### PR TITLE
Replaced stuff with STENCIL enums for simplicity

### DIFF
--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -11,40 +11,38 @@ function ENT:Draw()
 	if wp.drawing then return end
 	local shouldrender,drawblack=wp.shouldrender(self)
 	if not (shouldrender or drawblack) then return end
-	
+
 	local exitPortal = self:GetExit()
 	hook.Call("wp-predraw", GAMEMODE, self, exitPortal)
 
 	if shouldrender then
 		self:SetShouldDrawNextFrame( true )
-	
+
 		render.ClearStencil()
 		render.SetStencilEnable( true )
 
 		render.SetStencilWriteMask( 1 )
 		render.SetStencilTestMask( 1 )
+		render.SetStencilReferenceValue( 1 )
 
-		render.SetStencilFailOperation( STENCILOPERATION_KEEP )
-		render.SetStencilZFailOperation( STENCILOPERATION_KEEP )
-		render.SetStencilPassOperation( STENCILOPERATION_REPLACE )
-		render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_ALWAYS )
-		render.SetStencilReferenceValue( 1 )		
+		render.SetStencilFailOperation( STENCIL_KEEP )
+		render.SetStencilZFailOperation( STENCIL_KEEP )
+		render.SetStencilPassOperation( STENCIL_REPLACE )
+		render.SetStencilCompareFunction( STENCIL_ALWAYS )
 	end
-	
+
 	render.SetMaterial( wp.matDummy )
 	render.SetColorModulation( 1, 1, 1 )
-	render.DrawQuadEasy( self:GetPos() -( self:GetForward() *5), self:GetForward(), self:GetWidth(), self:GetHeight(), Color(0,0,0), self:GetAngles().roll )
-	
+	render.DrawQuadEasy( self:GetPos() -( self:GetForward() * 5 ), self:GetForward(), self:GetWidth(), self:GetHeight(), Color(0,0,0), self:GetAngles().roll )
+
 	if shouldrender then
-		render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_EQUAL )
-		render.SetStencilPassOperation( STENCILOPERATION_REPLACE )
-		render.SetStencilReferenceValue( 1 )
-		
+		render.SetStencilCompareFunction( STENCIL_EQUAL )
+
 		wp.matView:SetTexture( "$basetexture", self:GetTexture() )
 		render.SetMaterial( wp.matView )
 		render.DrawScreenQuad()
 		render.SetStencilEnable( false )
 	end
-	
+
 	hook.Call("wp-postdraw", GAMEMODE, self, exitPortal)
 end


### PR DESCRIPTION
I replaced [STENCILOPERATION](https://wiki.garrysmod.com/page/Enums/STENCILOPERATION) and [STENCILCOMPARISONFUNCTION](https://wiki.garrysmod.com/page/Enums/STENCILCOMPARISONFUNCTION) with [STENCIL](https://wiki.garrysmod.com/page/Enums/STENCIL) for the sake of simplicity. It functions exactly the same.

Also, I removed lines 40 and 41 because they did what was already done on lines 29 and 31.

Sorry for all these pull requests. You don't have to accept them.