### PR TITLE
Fixed incorrect portal selection & Rotate view roll leaving at 1 degree

### DIFF
--- a/lua/worldportals/teleport_cl.lua
+++ b/lua/worldportals/teleport_cl.lua
@@ -77,7 +77,7 @@ hook.Add("CalcView", "WorldPortals_RotateView", function(ply,pos,ang,fov)
 			wp.rotating = math.Approach(wp.rotating,0,FrameTime()*math.abs(wp.rotating-offset)*3.5)
 			local view={
 				origin=pos,
-				angles=Angle(ang.p,ang.y,wp.rotating+offset),
+				angles=Angle(ang.p,ang.y,wp.rotating - offset),
 				fov=fov
 			}
 			return view

--- a/lua/worldportals/teleport_cl.lua
+++ b/lua/worldportals/teleport_cl.lua
@@ -72,12 +72,11 @@ end )
 
 hook.Add("CalcView", "WorldPortals_RotateView", function(ply,pos,ang,fov)
 	if wp.rotating then
-		local offset=0.5 -- End transition smoothness (lower is smoother)
-		if math.abs(wp.rotating) > offset then
-			wp.rotating = math.Approach(wp.rotating,0,FrameTime()*math.abs(wp.rotating-offset)*3.5)
+		if wp.rotating ~= 0 then
+			wp.rotating = math.Approach(wp.rotating,0,FrameTime()*((0.5+math.abs(wp.rotating))*3.5))
 			local view={
 				origin=pos,
-				angles=Angle(ang.p,ang.y,wp.rotating - offset),
+				angles=Angle(ang.p,ang.y,wp.rotating),
 				fov=fov
 			}
 			return view

--- a/lua/worldportals/teleport_sh.lua
+++ b/lua/worldportals/teleport_sh.lua
@@ -1,28 +1,21 @@
 
 hook.Add("EntityFireBullets", "WorldPortals_Bullets", function(ent,data)
-	for k,v in pairs(ents.FindByClass("linked_portal_door")) do
-		if not IsValid(v:GetExit()) then continue end
+	local portal = wp.GetFirstPortalHit(data.Src, data.Dir)
+	if(IsValid(portal.Entity)) then
+		local localHitPos = portal.Entity:WorldToLocal(portal.HitPos)
+		local mins, maxs = portal.Entity:GetCollisionBounds()
+		if localHitPos.y > mins.y and localHitPos.y < maxs.y
+		and localHitPos.z > mins.z and localHitPos.z < maxs.z
+		and hook.Call("wp-trace", GAMEMODE, portal.Entity)~=false then
+			data.Src=wp.TransformPortalPos( portal.HitPos, portal.Entity, portal.Entity:GetExit() )
+			data.Dir=wp.TransformPortalAngle( data.Dir:Angle(), portal.Entity, portal.Entity:GetExit() ):Forward()
 
-		local hitPos = util.IntersectRayWithPlane(data.Src, data.Dir, v:GetPos(), v:GetForward())
-
-		if isvector(hitPos) then
-			local localHitPos = v:WorldToLocal(hitPos)
-			local mins, maxs = v:GetCollisionBounds()
-			if localHitPos.y > mins.y and localHitPos.y < maxs.y
-			and localHitPos.z > mins.z and localHitPos.z < maxs.z
-			and hook.Call("wp-trace", GAMEMODE, v)~=false then
-				data.Src=wp.TransformPortalPos( hitPos, v, v:GetExit() )
-							
-				local angle = wp.TransformPortalAngle( data.Dir:Angle(), v, v:GetExit() )
-				data.Dir=angle:Forward()
-
-				local filter =  hook.Call("wp-tracefilter", GAMEMODE, v)
-				if IsValid(filter) then
-					data.IgnoreEntity = filter
-				end
-				
-				return true
+			local filter =  hook.Call("wp-tracefilter", GAMEMODE, portal.Entity)
+			if IsValid(filter) then
+				data.IgnoreEntity = filter
 			end
+			
+			return true
 		end
 	end
 end)
@@ -30,49 +23,48 @@ end)
 if not util.RealTraceLine then
 	util.RealTraceLine = util.TraceLine
 end
+
 function WorldPortals_TraceLine(data)
 	local trace = util.RealTraceLine(data)
+	local portal = wp.GetFirstPortalHit(trace.StartPos, trace.Normal)
 
-	for k,v in pairs(ents.FindByClass("linked_portal_door")) do
-		if not (v.GetExit and IsValid(v:GetExit())) then continue end
-		local hitPos = util.IntersectRayWithPlane(trace.StartPos, trace.Normal, v:GetPos(), v:GetForward())
+	if(IsValid(portal.Entity)) then
+		local hitPos = portal.HitPos
 
-		if isvector(hitPos) then
-			local localHitPos = v:WorldToLocal(hitPos)
-			local mins, maxs = v:GetCollisionBounds()
-			if localHitPos.y > mins.y and localHitPos.y < maxs.y
-			and localHitPos.z > mins.z and localHitPos.z < maxs.z
-			and trace.Normal:Dot( v:GetForward() ) < 0
-			and hook.Call("wp-trace", GAMEMODE, v)~=false then
-				local angle = wp.TransformPortalAngle( trace.Normal:Angle(), v, v:GetExit() ):Forward()
-				local startPos = wp.TransformPortalPos( hitPos, v, v:GetExit() )
+		local localHitPos = portal.Entity:WorldToLocal(portal.HitPos)
+		local mins, maxs = portal.Entity:GetCollisionBounds()
 
-				local length = data.start:Distance(data.endpos)
-				local usedLength = trace.StartPos:Distance(trace.HitPos)
+		if localHitPos.y > mins.y and localHitPos.y < maxs.y
+		and localHitPos.z > mins.z and localHitPos.z < maxs.z
+		and hook.Call("wp-trace", GAMEMODE, portal.Entity)~=false then
+			local angle = wp.TransformPortalAngle( trace.Normal:Angle(), portal.Entity, portal.Entity:GetExit() ):Forward()
+			local startPos = wp.TransformPortalPos( portal.HitPos, portal.Entity, portal.Entity:GetExit() )
 
-				local endPos = angle
-				endPos:Mul(length + 32 - usedLength)
-				endPos:Add(startPos)
-				
-				local filter = hook.Call("wp-tracefilter", GAMEMODE, v)
-				if IsValid(filter) then
-					if trace.filter then
-						if type(trace.filter) == "table" then
-							table.insert(trace.filter, filter)
-						end
-					else
-						trace.filter = filter
+			local length = data.start:Distance(data.endpos)
+			local usedLength = portal.Distance
+
+			local endPos = angle
+			endPos:Mul(length + 32 - usedLength)
+			endPos:Add(startPos)
+			
+			local filter = hook.Call("wp-tracefilter", GAMEMODE, portal.Entity)
+			if IsValid(filter) then
+				if trace.filter then
+					if type(trace.filter) == "table" then
+						table.insert(trace.filter, filter)
 					end
+				else
+					trace.filter = filter
 				end
-				
-				local tr = util.RealTraceLine({
-					start = startPos,
-					endpos = endPos,
-					mask = trace.mask,
-					filter = trace.filter
-				})
-				return tr
 			end
+			
+			local tr = util.RealTraceLine({
+				start = startPos,
+				endpos = endPos,
+				mask = trace.mask,
+				filter = trace.filter
+			})
+			return tr
 		end
 	end
 	return trace

--- a/lua/worldportals/teleport_sh.lua
+++ b/lua/worldportals/teleport_sh.lua
@@ -1,7 +1,7 @@
 
 hook.Add("EntityFireBullets", "WorldPortals_Bullets", function(ent,data)
 	local portal = wp.GetFirstPortalHit(data.Src, data.Dir)
-	if(IsValid(portal.Entity)) then
+	if IsValid(portal.Entity) then
 		local localHitPos = portal.Entity:WorldToLocal(portal.HitPos)
 		local mins, maxs = portal.Entity:GetCollisionBounds()
 		if localHitPos.y > mins.y and localHitPos.y < maxs.y
@@ -10,7 +10,7 @@ hook.Add("EntityFireBullets", "WorldPortals_Bullets", function(ent,data)
 			data.Src=wp.TransformPortalPos( portal.HitPos, portal.Entity, portal.Entity:GetExit() )
 			data.Dir=wp.TransformPortalAngle( data.Dir:Angle(), portal.Entity, portal.Entity:GetExit() ):Forward()
 
-			local filter =  hook.Call("wp-tracefilter", GAMEMODE, portal.Entity)
+			local filter = hook.Call("wp-tracefilter", GAMEMODE, portal.Entity)
 			if IsValid(filter) then
 				data.IgnoreEntity = filter
 			end
@@ -28,7 +28,7 @@ function WorldPortals_TraceLine(data)
 	local trace = util.RealTraceLine(data)
 	local portal = wp.GetFirstPortalHit(trace.StartPos, trace.Normal)
 
-	if(IsValid(portal.Entity)) then
+	if IsValid(portal.Entity) then
 		local hitPos = portal.HitPos
 
 		local localHitPos = portal.Entity:WorldToLocal(portal.HitPos)

--- a/lua/worldportals/utils_sh.lua
+++ b/lua/worldportals/utils_sh.lua
@@ -52,3 +52,33 @@ function wp.TransformPortalAngle( angle, portal, exit_portal )
 	return w_angle
 
 end
+
+--Returns the first portal hit starting from a source position and given the direction of the vector
+function wp.GetFirstPortalHit(source, direction)
+	local portal = {
+		Entity = nil,
+		Distance = 0,
+		HitPos = Vector(0,0,0)
+	}
+	for k,v in pairs(ents.FindByClass("linked_portal_door")) do
+		if not IsValid(v:GetExit()) then continue end
+		local hitPos = util.IntersectRayWithPlane(source, direction, v:GetPos(), v:GetForward())
+
+		if isvector(hitPos) 
+		and direction:Dot( v:GetForward() ) < 0 then
+			local dist = source:Distance(v:GetPos())
+
+			if(portal.Distance == 0) then
+				portal.Distance = dist
+			end
+
+			if dist <= portal.Distance then
+				portal.Entity = v
+				portal.Distance = dist
+				portal.HitPos = hitPos
+			end
+		end
+	end
+
+	return portal
+end

--- a/lua/worldportals/utils_sh.lua
+++ b/lua/worldportals/utils_sh.lua
@@ -64,11 +64,10 @@ function wp.GetFirstPortalHit(source, direction)
 		if not IsValid(v:GetExit()) then continue end
 		local hitPos = util.IntersectRayWithPlane(source, direction, v:GetPos(), v:GetForward())
 
-		if isvector(hitPos) 
-		and direction:Dot( v:GetForward() ) < 0 then
+		if isvector(hitPos) and direction:Dot( v:GetForward() ) < 0 then
 			local dist = source:Distance(v:GetPos())
 
-			if(portal.Distance == 0) then
+			if portal.Distance == 0 then
 				portal.Distance = dist
 			end
 


### PR DESCRIPTION
Added a util function to get the closest portal hit given source pos and direction of vector, previously it was returning the first portal that was hit.
- wp.GetFirstPortalHit(source, direction)