### PR TITLE
Change Positions used, to prevent Vehicle Bug

### DIFF
--- a/lua/worldportals/render_cl.lua
+++ b/lua/worldportals/render_cl.lua
@@ -24,8 +24,8 @@ hook.Add( "PostRender", "WorldPortals_StartRender", function()
 end )
 
 function wp.shouldrender( portal, camOrigin, camAngle, camFOV )
-	if not camOrigin then camOrigin = GetViewEntity():EyePos() end
-	if not camAngle then camAngle = GetViewEntity():EyeAngles() end
+	if not camOrigin then camOrigin = EyePos() end
+	if not camAngle then camAngle = EyeAngles() end
 	if not camFOV then camFOV = LocalPlayer():GetFOV() end
 	local exitPortal = portal:GetExit()
 	local distance = camOrigin:Distance( portal:GetPos() )


### PR DESCRIPTION
The GetViewEntity Function gives back an VIew Entity that has its angles relative to a vehicle you have entered. (Local Coordinates)
This causes the angles and positions to be wrong and portals are not rendered correctly.
Using the global functions should be faster and works with vehicles.