### PR TITLE
Add IsDormant

### DIFF
--- a/lua/worldportals/render_cl.lua
+++ b/lua/worldportals/render_cl.lua
@@ -36,6 +36,7 @@ function wp.shouldrender( portal, camOrigin, camAngle, camFOV )
 	local override, drawblack = hook.Call( "wp-shouldrender", GAMEMODE, portal, exitPortal, camOrigin )
 	if override ~= nil then return override, drawblack end
 	
+	if portal:IsDormant() then return false end
 	
 	if not (disappearDist <= 0) and distance > disappearDist then return false end
 	


### PR DESCRIPTION
As explained in discord earlier this prevents portals that are not currently in a valid PVS, to be skipped. 
Caused an issue where rendering causes massive lag in very specific situations.