### PR TITLE
Added the ability to set the portal visuals to models 

### DIFF
--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -4,11 +4,15 @@ include( "shared.lua" )
 AccessorFunc( ENT, "texture", "Texture" )
 
 function ENT:DrawPortal(exitPortal)
-    if self:GetThickness() == 0 or hook.Call("wp-allowthickportal", GAMEMODE, self, exitPortal)==false then
+    if not (self:GetModel() == "models/error.mdl") then
+        render.ModelMaterialOverride( wp.matInvis )
+        render.Model({model = self:GetModel(), pos = self:LocalToWorld(self:GetModelPos()), angle = self:LocalToWorldAngles(self:GetModelAng())})
+        render.ModelMaterialOverride( false )
+    elseif self:GetThickness() == 0 or hook.Call("wp-allowthickportal", GAMEMODE, self, exitPortal)==false then
         render.DrawQuadEasy( self:GetPos() -( self:GetForward() * 5 ), self:GetForward(), self:GetWidth(), self:GetHeight(), color_black, self:GetAngles().roll )
     elseif self:GetInverted() then
         for _,quad in ipairs(self.RenderQuads) do
-            render.DrawQuad(self:LocalToWorld(quad[1]), self:LocalToWorld(quad[2]), self:LocalToWorld(quad[3]), self:LocalToWorld(quad[4]), color_black)     
+            render.DrawQuad(self:LocalToWorld(quad[1]), self:LocalToWorld(quad[2]), self:LocalToWorld(quad[3]), self:LocalToWorld(quad[4]), color_black)
         end
     else
         render.DrawBox(self:GetPos(), self:GetAngles(), self.RenderMin, self.RenderMax, color_black)
@@ -52,7 +56,7 @@ function ENT:Draw()
             render.SetStencilCompareFunction( STENCIL_ALWAYS )
         end
 
-        local transparency = self:GetTransparency()
+        local transparency =  120 --self:GetTransparency()
         if transparency > 0 then
             render.SetMaterial( wp.matTrans )
         else

--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -56,7 +56,7 @@ function ENT:Draw()
             render.SetStencilCompareFunction( STENCIL_ALWAYS )
         end
 
-        local transparency =  120 --self:GetTransparency()
+        local transparency = self:GetTransparency()
         if transparency > 0 then
             render.SetMaterial( wp.matTrans )
         else

--- a/lua/entities/linked_portal_door/shared.lua
+++ b/lua/entities/linked_portal_door/shared.lua
@@ -60,13 +60,16 @@ function ENT:SetupDataTables()
     self:NetworkVar( "Int", "Thickness" )
     self:NetworkVar( "Int", "Transparency" )
     self:NetworkVar( "Int", "ZFar" )
-    
+
     self:NetworkVar( "String", "CustomLink" )
-    
+
     self:NetworkVar( "Bool", "Inverted" )
 
     self:NetworkVar( "Vector", "ExitPosOffset" )
     self:NetworkVar( "Angle", "ExitAngOffset" )
+
+    self:NetworkVar( "Vector", "ModelPos" )
+    self:NetworkVar( "Angle", "ModelAng" )
 
     self:NetworkVarNotify("Width", function(ent, name, old, new) ent:SetupBounds(new) end)
     self:NetworkVarNotify("Height", function(ent, name, old, new) ent:SetupBounds(nil, new) end)

--- a/lua/worldportals/render_cl.lua
+++ b/lua/worldportals/render_cl.lua
@@ -2,6 +2,7 @@
 -- Setup variables
 wp.matBlack = Material( "wp/black" )
 wp.matTrans = Material( "wp/trans" )
+wp.matInvis = Material( "wp/invis" )
 wp.matView = CreateMaterial(
     "UnlitGeneric",
     "GMODScreenspace",

--- a/materials/wp/invis.vmt
+++ b/materials/wp/invis.vmt
@@ -1,0 +1,5 @@
+"VertexLitGeneric"
+{
+	"$color2" "[0 0 0]"
+	"$additive" "1"
+}


### PR DESCRIPTION
this makes it so you can set the portal visuals to be a model, the reason the model is set as and invisible texture is because despite the portal visuals being render over it, the model is still there under it, which would make it incompatible with transparent portals, this implementation also allows for offsetting the model