### PR TITLE
Clientside ConVar for changing the render resolution 

### DIFF
--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -3,7 +3,7 @@ include( "shared.lua" )
 
 AccessorFunc( ENT, "texture", "Texture" )
 
-local res_cvar = CreateClientConVar("worldportals_resolution_percentage", "100", true, false, "Doors - Render resolution percentage for portals")
+local res_cvar = CreateClientConVar("worldportals_resolution_percentage", "100", true, false, "World Portals - Render resolution percentage for portals")
 
 local res = ((GetConVar("worldportals_resolution_percentage"):GetInt())/100)
 

--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -3,6 +3,8 @@ include( "shared.lua" )
 
 AccessorFunc( ENT, "texture", "Texture" )
 
+local res_cvar = CreateClientConVar("doors_resolution_percentage", "100", true, false, "Doors - Render resolution percentage for portals")
+
 function ENT:DrawPortal(exitPortal)
     if not (self:GetModel() == "models/error.mdl") then
         render.ModelMaterialOverride( wp.matInvis )
@@ -29,7 +31,10 @@ function ENT:Draw()
     if not IsValid(exitPortal) then return end
     hook.Call("wp-predraw", GAMEMODE, self, exitPortal)
 
-    local width, height = ScrW(), ScrH()
+
+    local res = ((GetConVar("doors_resolution_percentage"):GetInt())/100)
+
+    local width, height = ScrW()*res, ScrH()*res
     local texture = GetRenderTarget("portal:" .. self:EntIndex() .. ":" .. width .. ":" .. height, width, height)
     self:SetTexture( texture )
 

--- a/lua/entities/linked_portal_door/cl_init.lua
+++ b/lua/entities/linked_portal_door/cl_init.lua
@@ -3,7 +3,13 @@ include( "shared.lua" )
 
 AccessorFunc( ENT, "texture", "Texture" )
 
-local res_cvar = CreateClientConVar("doors_resolution_percentage", "100", true, false, "Doors - Render resolution percentage for portals")
+local res_cvar = CreateClientConVar("worldportals_resolution_percentage", "100", true, false, "Doors - Render resolution percentage for portals")
+
+local res = ((GetConVar("worldportals_resolution_percentage"):GetInt())/100)
+
+cvars.AddChangeCallback("worldportals_resolution_percentage", function(convar_name, value_old, value_new)
+    res = value_new/100
+end)
 
 function ENT:DrawPortal(exitPortal)
     if not (self:GetModel() == "models/error.mdl") then
@@ -30,9 +36,6 @@ function ENT:Draw()
     local exitPortal = self:GetExit()
     if not IsValid(exitPortal) then return end
     hook.Call("wp-predraw", GAMEMODE, self, exitPortal)
-
-
-    local res = ((GetConVar("doors_resolution_percentage"):GetInt())/100)
 
     local width, height = ScrW()*res, ScrH()*res
     local texture = GetRenderTarget("portal:" .. self:EntIndex() .. ":" .. width .. ":" .. height, width, height)


### PR DESCRIPTION
this adds a small convar to let the user lower the render resolution of the portals so that they can still be used on slower hardware